### PR TITLE
Don't crash if no results found

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -28,3 +28,6 @@ asset_duration: 60
 
 # Should AWS Created resources be deleted at the end of the assessment (Note: The run/findings will be kept)
 cleanup_resources: true
+
+#Should we ignore it if inspector finds no results?
+ignore_no_results: false

--- a/lib/aws_inspector.rb
+++ b/lib/aws_inspector.rb
@@ -66,7 +66,12 @@ class Inspector
   end
 
   def describe_findings
-    @assessment_findings = aws.describe_findings(finding_arns: retrieve_finding_arns).findings
+    finding_arns = retrieve_finding_arns
+    if finding_arns.any?
+      aws.describe_findings(finding_arns: retrieve_finding_arns).findings
+    else
+      []
+    end
   end
 
   def evaluate_for_failure(report)

--- a/lib/aws_inspector.rb
+++ b/lib/aws_inspector.rb
@@ -8,6 +8,7 @@ class Inspector
     @rules_to_run = options['rules_to_run']
     @failure_metrics = options['failure_metrics']
     @resource_target_tags = options['target_tags'].collect { |k, v| { key: k, value: v.to_s } }
+    @ignore_no_results = options['ignore_no_results']
   end
 
   def run
@@ -51,7 +52,9 @@ class Inspector
       end
     end
   rescue Timeout::Error
-    # puts 'We could not get results from the assessment run in time'
+    unless @ignore_no_results == true
+      raise 'We could not get results from the assessment run in time'
+    end
   end
 
   def create_template

--- a/lib/aws_inspector.rb
+++ b/lib/aws_inspector.rb
@@ -51,7 +51,7 @@ class Inspector
       end
     end
   rescue Timeout::Error
-    puts 'We could not get results from the assessment run in time'
+    # puts 'We could not get results from the assessment run in time'
   end
 
   def create_template


### PR DESCRIPTION
We were finding that if inspector had no findings (usually because of short runs) then this would crash our CI pipeline.

In the instance where we wanted to store the results, we wanted a pure json output so we could store that in a parseable form too.

This also adds the option to raise an error (which is the default) if no findings are found.